### PR TITLE
修复了部分留言板的BUG

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,7 +526,7 @@
     <script src="ku/jquery-3.1.1.js"></script>
     <script src="ku/jquery-ui-1.10.2.js"></script>
     <script src="resume.js"></script>
-    <script src="ku\HomeWork\No.08 HomeWork 18-19.js"></script>
-    <script src="ku\HomeWork\No.08 HomeWork 17.js"></script>
+    <script src="ku/HomeWork/No.08 HomeWork 18-19.js"></script>
+    <script src="ku/HomeWork/No.08 HomeWork 17.js"></script>
 </body>
 </html>

--- a/resume.js
+++ b/resume.js
@@ -411,7 +411,7 @@ var comment = function(comments, id) {
                 <textarea id="id-comment-text" maxlength="${words}" placeholder="在此输入评论" rows="4" required></textarea>
                 <div id="id-comment-okay">
                     <span class="pure-button pure-button-disabled">还能输入
-                    <span   id="id-words">${words}</span> 个字</span>
+                    <span   id="id-words-left">${words}</span> 个字</span>
                     <input  id="id-comment-input" type="text" value="匿名" placeholder="昵称" maxlength="10" required>
                     <button id="id-comment-put" class="pure-button">提交评论</button>
                 </div>
@@ -419,14 +419,14 @@ var comment = function(comments, id) {
         </div>
         `
         $('body').append(html)
-        $('.comment-text').on('keydown', function() {
-            var word = words - $('#id-comment-text').val().length
-            $('#id-words').text(word)
+        $('.comment-text').on('keyup', function() {
+            var wordsLeft = words - $('#id-comment-text').val().length
+            $('#id-words-left').text(wordsLeft)
         })
         $('#id-comment-put').on('click', function(event) {
             var user = $('#id-comment-input').val()
             var text = $('#id-comment-text').val()
-            if (user.length >= 0 && text.length > 0) {
+            if (user.length > 0 && text.length > 0) {
                 var ku = {
                     No_: id + 1,
                     name: user,
@@ -449,13 +449,15 @@ var comment = function(comments, id) {
                 comments.push(ku)
                 localStorage.comments = JSON.stringify(comments)
             }
+            event.preventDefault()
+            $('#id-words-left').text(140)
         })
         $('body').on('dblclick', '.message-name', function(event) {
             $(event.target).closest('.message').remove()
             log('comments ID:', event.target.dataset.id)
             $(comments).each(function(i, e) {
                     if (String(e.No_) === event.target.dataset.id) {
-                        comments.splice(i, 1) // 删除 message 并保存 弟弟舔它
+                        comments.splice(i, 1) // 删除 message 并保存 弟弟舔它  <--发现了了不得的注释！
                         localStorage.comments = JSON.stringify(comments)
                     }
                 })


### PR DESCRIPTION
修复的BUG：
1、原页面计算字数不正确（总是比正确的多一个或者少一个）的BUG；
2、判定用户名长度不正确的BUG（会允许空昵称）；
3、在提交了非空回复之后不正确弹出“请填写此字段”的BUG；
4*、部分参数名不能准确表达意思(words->words-left)，可以忽略；
5*、了不得的注释，注意删掉（滑稽）。